### PR TITLE
Ambient.fromJSON

### DIFF
--- a/__tests__/From_JSON.re
+++ b/__tests__/From_JSON.re
@@ -1,0 +1,75 @@
+open Jest;
+open Expect;
+open Ambient;
+
+type capability = Capability.t;
+
+describe("From JSON", () => {
+  test("001", () => {
+    let json = {| { "id": "a", "type": "Noop" } |}
+    let amb: ambient = Ambient.fromJSON(json);
+    let expected = Ambient("a", [], [], [])
+    expect(amb) |> toEqual(expected)
+  });
+
+  test("002", () => {
+    let json = {| {
+      "children": [
+        {
+          "children": [{
+            "id": "b",
+            "type": "Noop"
+          }],
+          "id": "a",
+          "type": "Ambient"
+        },
+        {
+          "id": "c",
+          "type": "Noop"
+        }
+      ],
+      "type": "Parallel"
+    } |}
+    let amb: ambient = Ambient.fromJSON(json);
+    let expected = Parallel([
+      Ambient("a", [Ambient("b", [], [], [])], [], []),
+      Ambient("c", [], [], [])
+    ])
+    expect(amb) |> toEqual(expected)
+  });
+
+  test("003", () => {
+    let json = {|
+    {
+  "children": [
+    {
+      "children": [{
+        "id": "b",
+        "type": "In"
+      }],
+      "id": "a",
+      "type": "Ambient"
+    },
+    {
+      "children": [{
+        "id": "a",
+        "type": "In_"
+      }],
+      "id": "b",
+      "type": "Ambient"
+    }
+  ],
+  "type": "Parallel"
+}
+
+    |};
+    let amb: ambient = Ambient.fromJSON(json);
+    let expected =
+      Parallel([
+        Ambient("a", [], [In("b")], []),
+        Ambient("b", [], [In_("a")], [])
+      ])
+    expect(amb) |> toEqual(expected)
+  });
+});
+      // (* read [package.json] file *)

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -17,7 +17,7 @@
   },
   "suffix": ".bs.js",
   "bs-dependencies": [
-
+    "@glennsl/bs-json"
   ],
   "bs-dev-dependencies": [
     "@glennsl/bs-jest"

--- a/package-lock.json
+++ b/package-lock.json
@@ -225,6 +225,11 @@
         "jest": "^24.3.1"
       }
     },
+    "@glennsl/bs-json": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@glennsl/bs-json/-/bs-json-5.0.1.tgz",
+      "integrity": "sha512-tDxqeO4LCUz3HIwsdqyM4OIUk/bIV8QwDuhNbqy3hHIVEciePbJXTSyXMKsoIFs3ukQY8ZsQXskONtOK4TyLfA=="
+    },
     "@jest/console": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
@@ -1220,9 +1225,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.2.tgz",
-      "integrity": "sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
+      "integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.0",
@@ -1233,8 +1238,8 @@
         "is-regex": "^1.0.4",
         "object-inspect": "^1.6.0",
         "object-keys": "^1.1.1",
-        "string.prototype.trimleft": "^2.0.0",
-        "string.prototype.trimright": "^2.0.0"
+        "string.prototype.trimleft": "^2.1.0",
+        "string.prototype.trimright": "^2.1.0"
       }
     },
     "es-to-primitive": {
@@ -2173,9 +2178,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.0.tgz",
-      "integrity": "sha512-xkRtOt3/3DzTKMOt3xahj2M/EqNhY988T+imYSlMgs5fVhLN2fmKVVj0LtEGmb+3UUYV5Qmm1052Mm3dIQxOvw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.2.tgz",
+      "integrity": "sha512-cIv17+GhL8pHHnRJzGu2wwcthL5sb8uDKBHvZ2Dtu5s1YNt0ljbzKbamnc+gr69y7bzwQiBdr5+hOpRd5pnOdg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -3127,9 +3132,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-      "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+      "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.9",
     "bs-platform": "^5.0.6"
+  },
+  "dependencies": {
+    "@glennsl/bs-json": "^5.0.1"
   }
 }

--- a/src/Ambient.re
+++ b/src/Ambient.re
@@ -2,9 +2,53 @@ type name = Name.t;
 type capability = Capability.t;
 type transition('a) = Transition.t('a);
 
-/* Ambient has a name, list of children (nested ambients), list of (unused) capabilities and a list of "transitions", ie. capabilities that can be reduced in the next reduction */
+module Deserializer {
+  type node = {
+    nType: string,
+    id: option(string),
+    children: option(list(node)),
+  };
+
+  let filterAmbients = (nodes: list(node)) => {
+    List.filter((node) => {
+      switch node.nType {
+        | "Ambient" => true
+        | "Noop" => true
+        | "Parallel" => true
+        | _ => false
+        }
+    }, nodes)
+  }
+
+  let filterCapabilities = (nodes: list(node)) => {
+    List.filter((node) => {
+      switch node.nType {
+        | "In" => true
+        | "In_" => true
+        | _ => false
+      }
+    }, nodes)
+  }
+
+  let rec node = json => {
+    Json.Decode.{
+      id: json |> optional(field("id", string)),
+      nType: json |> field("type", string),
+      children: json |> optional(field("children", list(node)))
+    }
+  }
+}
+
+
+/* Ambient has:
+   - a name
+   - list of children (nested ambients)
+   - list of (unused) capabilities
+   - list of "transitions", ie. capabilities that can be reduced in the next reduction
+*/
 type ambient =
-  | Ambient(name, list(ambient), list(capability), list(transition(ambient)));
+  | Ambient(name, list(ambient), list(capability), list(transition(ambient)))
+  | Parallel(list(ambient));
 
 let empty (name): ambient = {
   Ambient(name, [], [], []);
@@ -13,6 +57,61 @@ let empty (name): ambient = {
 let create (name, children, capabilities, transitions): ambient = {
   Ambient(name, children, capabilities, transitions);
 };
+
+exception ID_Required(string);
+exception Children_Required(string);
+exception Unrecognized(string);
+
+let fromJSON(json) = {
+  let ast = json |> Json.parseOrRaise |> Deserializer.node;
+
+  let parseCapability = (node: Deserializer.node) => {
+    switch node.nType {
+    | "In" => switch node.id {
+      | Some(id) => Capability.In(id)
+      | None => raise(ID_Required("ID is required"));
+      }
+    | "In_" => switch node.id {
+      | Some(id) => Capability.In_(id)
+      | None => raise(ID_Required("ID is required"));
+      }
+    | _ => raise(Unrecognized("Unrecognized Capability"))
+    }
+  }
+
+  let rec parseAmbient = (node: Deserializer.node) => {
+    switch node.nType {
+    | "Ambient" => switch node.id {
+      | Some(id) => {
+        switch node.children {
+        | Some(children) => {
+          let childs = Deserializer.filterAmbients(children) |> List.map(parseAmbient);
+          let capabilities = Deserializer.filterCapabilities(children) |> List.map(parseCapability);
+          let transitions = [];
+          Ambient(id, childs, capabilities, transitions)
+        }
+        | None => Ambient(id, [], [], [])
+        }
+      }
+      | None => raise(ID_Required("ID is required"))
+      }
+    | "Parallel" => switch node.children {
+      | Some(children) => {
+        let childs = List.map(parseAmbient, children);
+        Parallel(childs)
+      }
+      | None => raise(Children_Required("Children are required"))
+      }
+    | "Noop" => switch node.id {
+      | Some(id) => Ambient(id, [], [], [])
+      | None => raise(ID_Required("ID is required"));
+      }
+    | _ => raise(Unrecognized("Unrecognized node type"))
+    }
+  }
+
+  parseAmbient(ast);
+}
 
 let getName (ambient) = {
   switch ambient {


### PR DESCRIPTION
This PR implements stage 2 of the compiler. It takes the preliminary JSON AST from ambient syntax, which is exceedingly simple:

```
{
  "id": "string"
  "type": "enum as string"
  "children": [ ... array of nodes just like this one ... ]
}
```

...and creates proper ReasonML types out of them, to then be fed into the reducer, or wherever they're needed.